### PR TITLE
Allow specifying the client class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf-balancer gem.
 
 ### Pending release
 
+- Allow configuring the client class when adding a client
+
 ### 0.0.1
 
 - Initial release

--- a/lib/gruf/balancer/client.rb
+++ b/lib/gruf/balancer/client.rb
@@ -43,11 +43,14 @@ module Gruf
       # @param [Float] percentage The percentage of requests to weight by (0-100)
       # @param [Hash] options Options to pass-through to the Gruf::Client
       # @param [Hash] client_options gRPC Client Options to pass-through to the Gruf::Client
+      # @param [Class] client_class The client class to use. Useful if wanting to create a Gruf::SynchronizedClient or
+      #   other derivative client
       #
-      def add_client(percentage:, options: {}, client_options: {})
+      def add_client(percentage:, options: {}, client_options: {}, client_class: nil)
+        client_class ||= ::Gruf::Client
         percentage = percentage > 100.0 ? 100.0 : percentage.to_f
         percentage = percentage < 0.0 ? 0.0 : percentage
-        cl = Gruf::Client.new(
+        cl = client_class.new(
           service: @service,
           options: @options.merge(options),
           client_options: @client_options.merge(client_options)

--- a/spec/unit/gruf/balancer/client_spec.rb
+++ b/spec/unit/gruf/balancer/client_spec.rb
@@ -20,10 +20,11 @@ require 'spec_helper'
 describe Gruf::Balancer::Client do
   let(:options) { {} }
   let(:client_options) { {} }
+  let(:client_class) { nil }
   let(:client) { described_class.new(service: TestService, options: options, client_options: client_options) }
 
   describe '#add_client' do
-    subject { client.add_client(percentage: percentage, options: sub_options, client_options: sub_client_options) }
+    subject { client.add_client(percentage: percentage, options: sub_options, client_options: sub_client_options, client_class: Gruf::SynchronizedClient) }
 
     let(:sub_options) { {} }
     let(:sub_client_options) { {} }
@@ -61,6 +62,16 @@ describe Gruf::Balancer::Client do
 
         expect(derived_client).to be_a(Gruf::Client)
         expect(actual_weight).to eq 1.0
+      end
+    end
+
+    context 'with a custom client class' do
+      let(:client_class) { Gruf::SynchronizedClient }
+
+      it 'creates the client with the custom class' do
+        expect { subject }.not_to raise_error
+
+        expect(derived_client).to be_a(Gruf::SynchronizedClient)
       end
     end
   end


### PR DESCRIPTION
## What?

Certain systems use `Gruf::SynchronizedClient`, or other derivative classes, to create their clients. We want to allow that functionality, so this allows passing a `client_class` argument when adding a client to specify what class should be used for instantiation.

---

@bigcommerce/ruby @chrisboulton 