### PR TITLE
Add Ruby 3.0 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,17 +160,17 @@ workflows:
       - e2e:
           name: "ruby-2_7-e2e"
           e: "ruby_2_7"
-#  ruby_3_0:
-#    jobs:
-#      - bundle-audit:
-#          name: "ruby-3_0-bundle_audit"
-#          e: "ruby_3_0"
-#      - rubocop:
-#          name: "ruby-3_0-rubocop"
-#          e: "ruby_3_0"
-#      - rspec-unit:
-#          name: "ruby-3_0-rspec"
-#          e: "ruby_3_0"
-#      - e2e:
-#          name: "ruby-3_0-e2e"
-#          e: "ruby_3_0"
+  ruby_3_0:
+    jobs:
+      - bundle-audit:
+          name: "ruby-3_0-bundle_audit"
+          e: "ruby_3_0"
+      - rubocop:
+          name: "ruby-3_0-rubocop"
+          e: "ruby_3_0"
+      - rspec-unit:
+          name: "ruby-3_0-rspec"
+          e: "ruby_3_0"
+      - e2e:
+          name: "ruby-3_0-e2e"
+          e: "ruby_3_0"

--- a/gruf-balancer.gemspec
+++ b/gruf-balancer.gemspec
@@ -32,11 +32,10 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['README.md', 'CHANGELOG.md', 'CODE_OF_CONDUCT.md', 'lib/**/*', 'gruf-balancer.gemspec']
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.6', '< 3.1'
+  spec.required_ruby_version = '>= 2.6'
 
   spec.add_development_dependency 'benchmark-memory', '0.1.2'
   spec.add_development_dependency 'bundler-audit', '>= 0.6'
-  spec.add_development_dependency 'google-protobuf', '3.14.0'
   spec.add_development_dependency 'pry', '>= 0.12'
   spec.add_development_dependency 'pry-byebug', '>= 3.9'
   spec.add_development_dependency 'rspec', '>= 3.8'


### PR DESCRIPTION
Adds Ruby 3.0 support. Removes the explicit 3.1 restriction (until we have a reason to restrict it) and the google-protobuf restriction (no longer necessary).

---

@bigcommerce/ruby @bigcommerce/oss-maintainers 